### PR TITLE
Add a way to use JWTAuthentication via middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ In order to protect other views with such authentication tokens, simply mark the
 authentication method as `rest_framework_simplejwt.authentication.JWTAuthentication`
 or similar as, or set it globally using `DEFAULT_AUTHENTICATION_CLASSES`.
 
+### Middleware-based authentication
+
+`django-restframework` and `drf-simplejwt` provide view-based authentication,
+meaning that by default authentication is handled by DRF _after_ middleware has
+run. This is usually not a big issue unless you have other middleware that
+requires accessing e.g. the user object, this can happen when doing traceability
+and you want to log the currently logged-in user for every request.
+
+`django-kaminarimon` provides a way to authenticate the user using the
+authentication class from `drf-simplejwt` in middleware, meaning that
+request.user gets populated before reaching the corresponding DRF view.
+
+The DRF view won't count the user as authenticated unless it also uses
+the accompanying authentication class which can be set per-view or in
+`DEFAULT_AUTHENTICATION_CLASSES`, like with any other DRF authentication
+class.
+
+To enable, add `kaminarimon.middleware.JWTAuthenticationMiddleware` to your
+Django settings and `kaminarimon.auth.MiddlewareJWTAuthentication` either to
+your `DEFAULT_AUTHENTICATION_CLASSES` or to individual views.
+
 ## Browser-based applications
 
 If your service will be used by browser-based applications and security of tokens

--- a/kaminarimon/auth.py
+++ b/kaminarimon/auth.py
@@ -1,11 +1,20 @@
 import socket
+from typing import Optional, TypeVar
 
+from django.contrib.auth.models import AbstractBaseUser
 import kerberos
 from django.conf import settings
 from django.contrib.auth import authenticate
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from rest_framework import authentication
 from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.request import Request
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.models import TokenUser
+from rest_framework_simplejwt.tokens import Token
+
+
+AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
 
 class KerberosAuthentication(authentication.BaseAuthentication):
@@ -66,3 +75,10 @@ class KerberosAuthenticationScheme(OpenApiAuthenticationExtension):
             "scheme": "negotiate",
             "in": "header",
         }
+
+
+class MiddlewareJWTAuthentication(JWTAuthentication):
+    def authenticate(self, request: Request) -> Optional[tuple[AuthUser, Token]]:
+        user = request._request.user
+        if user.is_authenticated:
+            return (user, None)

--- a/kaminarimon/middleware.py
+++ b/kaminarimon/middleware.py
@@ -1,0 +1,24 @@
+from typing import Callable
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpRequest, HttpResponse
+from django.utils.functional import SimpleLazyObject
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken
+
+
+class JWTAuthenticationMiddleware:
+    def __init__(self, get_response: Callable) -> None:
+        self.get_response = get_response
+        self.authenticator = JWTAuthentication()
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        def get_user():
+            try:
+                user_auth_tuple = self.authenticator.authenticate(request)
+            except InvalidToken:
+                return AnonymousUser()
+            if user_auth_tuple is None:
+                return AnonymousUser()
+            return user_auth_tuple[0]
+        request.user = SimpleLazyObject(lambda: get_user())
+        return self.get_response(request)

--- a/tests/cookie_test_app/middleware.py
+++ b/tests/cookie_test_app/middleware.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Callable
+from django.http import HttpRequest, HttpResponse
+
+logger = logging.getLogger(__name__)
+
+
+class TestUserMiddleware:
+    """
+    Test middleware that accesses request.user and logs it along with the requested path
+    for traceability purposes. This verifies that the JWT middleware correctly sets request.user.
+    """
+    def __init__(self, get_response: Callable) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        # Access request.user to verify it's set correctly by the JWT middleware
+        # This should trigger the SimpleLazyObject evaluation
+        user = request.user
+
+        # Log the user and requested path for traceability
+        user_str = str(user) if user else "None"
+        logger.info(f"Request to {request.path} by user: {user_str}")
+
+        return self.get_response(request)
+

--- a/tests/cookie_test_app/urls.py
+++ b/tests/cookie_test_app/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
 from kaminarimon.views import refresh_token
-from tests.cookie_test_app.views import obtain_token_pair_view
+from tests.cookie_test_app.views import obtain_token_pair_view, test_user_view
 
 urlpatterns = [
     path("auth/token", obtain_token_pair_view, name="token_obtain"),
     path("auth/token/refresh", refresh_token, name="token_refresh"),
+    path("test/user", test_user_view, name="test_user"),
 ]

--- a/tests/cookie_test_app/views.py
+++ b/tests/cookie_test_app/views.py
@@ -1,10 +1,11 @@
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.decorators import (api_view, authentication_classes,
                                        permission_classes)
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from kaminarimon.auth import MiddlewareJWTAuthentication
 from kaminarimon.views import _handle_jwt_auth
 
 
@@ -13,3 +14,10 @@ from kaminarimon.views import _handle_jwt_auth
 @permission_classes((IsAuthenticated,))
 def obtain_token_pair_view(request: Request) -> Response:
     return _handle_jwt_auth(request)
+
+
+@api_view()
+@authentication_classes((MiddlewareJWTAuthentication,))
+@permission_classes((IsAuthenticated,))
+def test_user_view(request: Request) -> Response:
+    return Response({"status": "ok"})

--- a/tests/test_jwt_middleware.py
+++ b/tests/test_jwt_middleware.py
@@ -1,0 +1,58 @@
+import logging
+
+import pytest
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
+
+pytestmark = pytest.mark.unit
+
+
+def test_jwt_middleware_with_authenticated_user(client, admin_user, caplog):
+    """
+    Test that the JWT middleware correctly sets request.user to the authenticated user
+    when a valid JWT token is provided.
+    """
+    refresh_token = RefreshToken.for_user(admin_user)
+    access_token = str(refresh_token.access_token)
+
+    with caplog.at_level(logging.INFO, logger="tests.cookie_test_app.middleware"):
+        response = client.get(
+            "/test/user",
+            HTTP_AUTHORIZATION=f"Bearer {access_token}"
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    # Verify that the log was emitted with the correct user
+    assert len(caplog.records) == 1
+    log_record = caplog.records[0]
+    assert log_record.levelname == "INFO"
+    assert "/test/user" in log_record.message
+    assert str(admin_user) in log_record.message or admin_user.username in log_record.message
+
+
+def test_jwt_middleware_without_token(client, caplog):
+    with caplog.at_level(logging.INFO, logger="tests.cookie_test_app.middleware"):
+        response = client.get("/test/user")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_jwt_middleware_with_invalid_token(client, caplog):
+    with caplog.at_level(logging.INFO, logger="tests.cookie_test_app.middleware"):
+        response = client.get(
+            "/test/user",
+            HTTP_AUTHORIZATION="Bearer invalid_token_12345"
+        )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_middleware_jwt_auth_requires_jwt_token_not_basic_auth(client, admin_user, basic_auth_header, caplog):
+    with caplog.at_level(logging.INFO, logger="tests.cookie_test_app.middleware"):
+        response = client.get(
+            "/test/user",
+            HTTP_AUTHORIZATION=basic_auth_header
+        )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,6 +25,8 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "kaminarimon.middleware.JWTAuthenticationMiddleware",
+    "tests.cookie_test_app.middleware.TestUserMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
This aligns with the Django way of authentication and enables JWT-authenticated users to be available through the request object in other middleware, for traceability/logging purposes for example.