### PR TITLE
fix: remove invalid field from Kerberos OpenAPI security scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-07
+
+### Fixed
+
+- Remove invalid 'in: header' field from Kerberos OpenAPI security scheme definition
+
 ## [0.2.1] - 2025-06-03
 
 ### Fixed

--- a/kaminarimon/auth.py
+++ b/kaminarimon/auth.py
@@ -64,5 +64,4 @@ class KerberosAuthenticationScheme(OpenApiAuthenticationExtension):
         return {
             "type": "http",
             "scheme": "negotiate",
-            "in": "header",
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "djangorestframework",
     "DRF",
 ]
-version = "0.2.1"
+version = "0.2.2"
 description = "Auth(n/z) plugin for Django using kerberos + LDAP"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
KerberosAuthenticationScheme.get_security_definition() method returns in: header which is invalid for type: http schemes as per the official OpenAPI specification (section 4.7.27, here in only applies to apiKey type). This causes openapi-spec-validator to fail.
Removed the invalid "in" :"header" field from get_security_definition().