### PR TITLE
OSIDB-4845: Migrate off anonymous LDAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Simple bind fallback for test/dev environments without Kerberos
+- `KAMINARIMON_LDAP_BASE_DN` setting to configure base DN (defaults to IPA)
+- `KAMINARIMON_LDAP_TIMEOUT` setting for LDAP operation timeouts (defaults to
+  10 seconds)
+- `escape_filter_chars` to LDAP search filters to prevent injection
+
+### Changed
+
+- Migrated LDAP directory from legacy Red Hat LDAP (`dc=redhat,dc=com`) to IPA
+  LDAP (`dc=ipa,dc=redhat,dc=com`)
+- Replaced anonymous LDAP bind with GSSAPI (Kerberos) as default
+  authentication method to LDAP server
+- Renamed settings:
+  - `AUTH_LDAP_SERVER_URI` (single string) → `KAMINARIMON_LDAP_SERVERS` (list)
+  - New: `KAMINARIMON_LDAP_BIND_DN`, `KAMINARIMON_LDAP_BIND_PASSWORD`
+- Single LDAP connection per authentication request instead of one per query
+- Group search uses `groupOfNames`/`member` to match the IPA group schema,
+  instead of the legacy directory's `groupOfUniqueNames`/`uniqueMember`
+- User search uses `uid` attribute under `cn=users,cn=accounts` (IPA structure)
+
+### Removed
+
+- Removed service account fallback search in separate `ou=serviceaccounts`
+  container (IPA stores all accounts in `cn=users`)
+- Removed anonymous LDAP bind support
+
 ## [0.2.2] - 2026-04-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,14 +30,12 @@ the client, signaling that it should use SPNEGO protocol for authentication.
 
 > [!NOTE]
 > A lot of the behavior of this authentication backend is currently hardcoded
-> to only work with Red Hat systems.
+> to only work with Red Hat IPA LDAP systems (`dc=ipa,dc=redhat,dc=com`).
 
-> [!NOTE]
-> Anonymous user access to the LDAP server is required for querying user
-> information.
+<!-- -->
 
 > [!WARNING]
-> Usage of LDAP authorization on its own withour Kerberos authentication is
+> Usage of LDAP authorization on its own without Kerberos authentication is
 > discouraged as it **only** handles authorization, it does not actually
 > perform any sort of authentication of the user against the LDAP server,
 > i.e. it simply loads the user's groups from the LDAP server.
@@ -45,11 +43,28 @@ the client, signaling that it should use SPNEGO protocol for authentication.
 Simply add the `kaminarimon.backend.LDAPRemoteUser` to the
 `AUTHENTICATION_BACKENDS` django setting.
 
-Required settings:
-* `AUTH_LDAP_SERVER_URI` -- URI to the LDAP server
+#### LDAP connection
+
+The following settings configure the LDAP connection:
+
+| Setting | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `KAMINARIMON_LDAP_SERVERS` | `list[str]` | Yes | — | LDAP server URIs |
+| `KAMINARIMON_LDAP_BIND_DN` | `str` | No | `None` | Bind DN for simple bind (if unset, GSSAPI is used) |
+| `KAMINARIMON_LDAP_BIND_PASSWORD` | `str` | No | — | Bind password for simple bind (required when `BIND_DN` is set) |
+| `KAMINARIMON_LDAP_TIMEOUT` | `int` | No | `10` | LDAP network and operation timeout in seconds |
+| `KAMINARIMON_LDAP_BASE_DN` | `str` | No | `dc=ipa,dc=redhat,dc=com` | Base DN for LDAP searches |
+
+When `KAMINARIMON_LDAP_BIND_DN` is not set, kaminarimon uses GSSAPI (Kerberos)
+to authenticate to the LDAP server. When set, it uses simple bind with the
+provided DN and password. Simple bind is useful for test and development
+environments where Kerberos is not available.
+
+#### Required application settings
+
 * `PUBLIC_READ_GROUPS` -- List of names of groups that, if the user is a member of,
   grant access to the application.
-  `SERVICE_MANAGE_GROUP` -- Group that denotes a user as staff and/or superuser.
+* `SERVICE_MANAGE_GROUP` -- Group that denotes a user as staff and/or superuser.
 
 ### Intended usage (kerberos authentication, ldap authorization)
 

--- a/kaminarimon/backend.py
+++ b/kaminarimon/backend.py
@@ -6,40 +6,71 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import Group
+from django.core.exceptions import ImproperlyConfigured
+from ldap.filter import escape_filter_chars
 from rest_framework.exceptions import AuthenticationFailed
 
 
-# Global TODO: Move hardcoded data into settings
-def get_ldap_groups(user_dn):
-    # TODO: move into class and do connection only once on init
-    conn = ldap.initialize(settings.AUTH_LDAP_SERVER_URI, bytes_mode=False)
+LDAP_DEFAULT_BASE_DN = "dc=ipa,dc=redhat,dc=com"
+
+def _ldap_connect():
+    servers = getattr(settings, "KAMINARIMON_LDAP_SERVERS", None)
+    if not servers:
+        raise ImproperlyConfigured(
+            "KAMINARIMON_LDAP_SERVERS must be set in Django settings"
+        )
+
+    conn = ldap.initialize(" ".join(servers), bytes_mode=False)
     conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
-    conn.simple_bind_s("", "")
-    group_base = "ou=adhoc,ou=managedgroups,dc=redhat,dc=com"
-    filter = f"(&(objectClass=groupOfUniqueNames)(uniqueMember={user_dn}))"
-    attrlist = ["cn"]
-    groups = conn.search_s(group_base, ldap.SCOPE_SUBTREE, filter, attrlist)
+
+    timeout = getattr(settings, "KAMINARIMON_LDAP_TIMEOUT", 10)
+    conn.set_option(ldap.OPT_NETWORK_TIMEOUT, timeout)
+    conn.set_option(ldap.OPT_TIMEOUT, timeout)
+
+    bind_dn = getattr(settings, "KAMINARIMON_LDAP_BIND_DN", None)
+    if bind_dn:
+        # Simple bind for test/dev environments without Kerberos
+        bind_password = getattr(settings, "KAMINARIMON_LDAP_BIND_PASSWORD", "")
+        if not bind_password:
+            raise ImproperlyConfigured(
+                "KAMINARIMON_LDAP_BIND_PASSWORD must be set when using "
+                "KAMINARIMON_LDAP_BIND_DN (empty password results in "
+                "anonymous bind)"
+            )
+        conn.simple_bind_s(bind_dn, bind_password)
+    else:
+        conn.sasl_gssapi_bind_s()
+
+    return conn
+
+# Global TODO: Move hardcoded data into settings
+def get_ldap_groups(user_dn, conn):
+    base_dn = getattr(settings, "KAMINARIMON_LDAP_BASE_DN", LDAP_DEFAULT_BASE_DN)
+    group_base = f"cn=groups,cn=accounts,{base_dn}"
+    groups = conn.search_s(
+        group_base,
+        ldap.SCOPE_SUBTREE,
+        f"(member={escape_filter_chars(user_dn)})",
+        ["cn"],
+    )
     return {group[1]["cn"][0].decode() for group in groups}
 
 
-def get_user_info(username):
-    conn = ldap.initialize(settings.AUTH_LDAP_SERVER_URI, bytes_mode=False)
-    conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
-    conn.simple_bind_s("", "")
-    base = "ou=%s,dc=redhat,dc=com"
+def get_user_info(username, conn):
+    base_dn = getattr(settings, "KAMINARIMON_LDAP_BASE_DN", LDAP_DEFAULT_BASE_DN)
+    user_base = f"cn=users,cn=accounts,{base_dn}"
     attrlist = ["givenName", "sn", "mail"]
     user = conn.search_s(
-        base % "users", ldap.SCOPE_SUBTREE, f"(uid={username})", attrlist
+        user_base,
+        ldap.SCOPE_SUBTREE,
+        f"(uid={escape_filter_chars(username)})",
+        attrlist
     )
     if not user:
-        user = conn.search_s(
-            base % "serviceaccounts", ldap.SCOPE_SUBTREE, f"(uid={username})", attrlist
+        # TODO: log mismatched username
+        raise AuthenticationFailed(
+            "Could not find matching LDAP account for Kerberos principal"
         )
-        if not user:
-            # TODO: log mismatched username
-            raise AuthenticationFailed(
-                "Could not find matching LDAP account for Kerberos principal"
-            )
     return user[0]
 
 
@@ -86,8 +117,14 @@ class LDAPRemoteUser(ModelBackend):
         Synchronize the user with the external system and return the updated user.
         """
         username = user.get_username()
-        dn, attrs = get_user_info(username)
-        groups = get_ldap_groups(dn)
+
+        conn = _ldap_connect()
+        try:
+            dn, attrs = get_user_info(username, conn)
+            groups = get_ldap_groups(dn, conn)
+        finally:
+            conn.unbind_s()
+
         # Note: we simply create Groups without handling Django-style permissions
         # since we don't really use them -- we use PostgreSQL RLS
         group_objs = [Group.objects.get_or_create(name=group)[0] for group in groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,13 @@ import base64
 
 import pytest
 
-from kaminarimon.backend import LDAPRemoteUser
+from kaminarimon.backend import _ldap_connect, LDAPRemoteUser
 
+@pytest.fixture
+def ldap_conn():
+    conn = _ldap_connect()
+    yield conn
+    conn.unbind_s()
 
 @pytest.fixture
 def normal_user():

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,12 +2,12 @@ version: '3'
 services:
     testldap:
       container_name: kaminarimon_ldap
-      image: mirror.gcr.io/bitnami/openldap:2.5
+      image: mirror.gcr.io/bitnami/openldap:2.6.10
       ports:
         - '6969:1389'
         - '7070:1636'
       environment:
-        - LDAP_ROOT=dc=redhat,dc=com
+        - LDAP_ROOT=dc=ipa,dc=redhat,dc=com
         - LDAP_ADMIN_USERNAME=admin
         - LDAP_ADMIN_PASSWORD=adminpassword
         - LDAP_CUSTOM_LDIF_DIR=/ldifs

--- a/tests/ldifs/test.ldif
+++ b/tests/ldifs/test.ldif
@@ -4,54 +4,55 @@ version: 1
 # top level
 #################
 
-dn: dc=redhat,dc=com
-dc: redhat
+dn: dc=ipa,dc=redhat,dc=com
+dc: ipa
 o: example
 objectclass: dcObject
 objectclass: organization
 
-dn: ou=users,dc=redhat,dc=com
-objectclass: organizationalUnit
-ou: users
+dn: cn=accounts,dc=ipa,dc=redhat,dc=com
+cn: accounts
+objectclass: organizationalRole
 
-dn: ou=serviceaccounts,dc=redhat,dc=com
-objectclass: organizationalUnit
-ou: serviceaccounts
+dn: cn=users,cn=accounts,dc=ipa,dc=redhat,dc=com
+cn: users
+objectclass: organizationalRole
+
+dn: cn=groups,cn=accounts,dc=ipa,dc=redhat,dc=com
+cn: groups
+objectclass: organizationalRole
 
 #################
 # Users
 #################
 
-dn: cn=testuser,ou=users,dc=redhat,dc=com
-cn: User01
+dn: uid=testuser,cn=users,cn=accounts,dc=ipa,dc=redhat,dc=com
 cn: testuser
-gidnumber: 1000
 givenName: Monke
-homedirectory: /home/testuser
-mail: monke@banana.com
-objectclass: inetOrgPerson
-objectclass: posixAccount
-objectclass: shadowAccount
 sn: Perlis
 uid: testuser
-uidnumber: 1000
+mail: monke@banana.com
+objectclass: inetOrgPerson
 userpassword: password
 
 #################
 # Service accounts
 #################
 
-dn: cn=testservice,ou=serviceaccounts,dc=redhat,dc=com
-cn: Service1
+dn: uid=testservice,cn=users,cn=accounts,dc=ipa,dc=redhat,dc=com
 cn: testservice
-gidnumber: 2000
 givenName: silenceawarning
-homedirectory: /home/testservice
-mail: silenceawarning
-objectclass: inetOrgPerson
-objectclass: posixAccount
-objectclass: shadowAccount
 sn: Faker
 uid: testservice
-uidnumber: 2000
+mail: silenceawarning
+objectclass: inetOrgPerson
 userpassword: password
+
+#################
+# Groups
+#################
+
+dn: cn=testgroup,cn=groups,cn=accounts,dc=ipa,dc=redhat,dc=com
+cn: testgroup
+objectclass: groupOfNames
+member: uid=testuser,cn=users,cn=accounts,dc=ipa,dc=redhat,dc=com

--- a/tests/test_krb5_ldap_mapping.py
+++ b/tests/test_krb5_ldap_mapping.py
@@ -1,7 +1,7 @@
 import pytest
 from rest_framework.exceptions import AuthenticationFailed
 
-from kaminarimon.backend import get_user_info
+from kaminarimon.backend import get_user_info, get_ldap_groups
 
 pytestmark = pytest.mark.unit
 
@@ -30,20 +30,23 @@ class TestCleanUsername:
 
 
 class TestLDAPCommunication:
-    def test_user_info_valid_user(self, valid_user_username):
-        user_info = get_user_info(valid_user_username)
-        dn, attrs = user_info
-        assert dn == f"cn={valid_user_username},ou=users,dc=redhat,dc=com"
+    def test_user_info_valid_user(self, ldap_conn, valid_user_username):
+        dn, attrs = get_user_info(valid_user_username, ldap_conn)
+        assert dn == f"uid={valid_user_username},cn=users,cn=accounts,dc=ipa,dc=redhat,dc=com"
         assert attrs["sn"][0].decode() == "Perlis"
 
-    def test_user_info_valid_service(self, valid_service_username):
-        user_info = get_user_info(valid_service_username)
-        dn, attrs = user_info
-        assert dn == f"cn={valid_service_username},ou=serviceaccounts,dc=redhat,dc=com"
+    def test_user_info_valid_service(self, ldap_conn, valid_service_username):
+        dn, attrs = get_user_info(valid_service_username, ldap_conn)
+        assert dn == f"uid={valid_service_username},cn=users,cn=accounts,dc=ipa,dc=redhat,dc=com"
         assert attrs["sn"][0].decode() == "Faker"
 
-    def test_user_info_invalid_service(self, invalid_service_username):
+    def test_user_info_invalid_service(self, ldap_conn, invalid_service_username):
         with pytest.raises(AuthenticationFailed) as e:
-            get_user_info(invalid_service_username)
+            get_user_info(invalid_service_username, ldap_conn)
         msg = "Could not find matching LDAP account for Kerberos principal"
         assert msg == str(e.value)
+
+    def test_ldap_groups(self, ldap_conn, valid_user_username):
+        dn, _ = get_user_info(valid_user_username, ldap_conn)
+        groups = get_ldap_groups(dn, ldap_conn)
+        assert "testgroup" in groups

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -51,7 +51,12 @@ REST_FRAMEWORK = {
     ],
 }
 
-AUTH_LDAP_SERVER_URI = "ldap://127.0.0.1:6969"
+KAMINARIMON_LDAP_SERVERS = ["ldap://127.0.0.1:6969"]
+KAMINARIMON_LDAP_BIND_DN = "cn=admin,dc=ipa,dc=redhat,dc=com"
+KAMINARIMON_LDAP_BIND_PASSWORD = "adminpassword"
+KAMINARIMON_LDAP_BASE_DN = "dc=ipa,dc=redhat,dc=com"
+PUBLIC_READ_GROUPS = ["testgroup"]
+SERVICE_MANAGE_GROUP = "testgroup"
 
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"


### PR DESCRIPTION
Part of [OSIDB-4845](https://redhat.atlassian.net/browse/OSIDB-4845)

Migrate LDAP from legacy Red Hat LDAP (dc=redhat,dc=com) to IPA LDAP (dc=ipa,dc=redhat,dc=com).

- Anonymous bind was replaced with two options:
    - GSSAPI - default
    - Simple bind - fallback for test/dev environments
- Setting names renamed from AUTH_LDAP_* to KAMINARIMON_* to avoid conflicts. (django-auth-ldap is no longer used in deployed OSIDB)
- KAMINARIMON_LDAP_SERVERS (list of URIs) is now required
- Single LDAP connection per auth request instead of one per query

[OSIDB-4845]: https://redhat.atlassian.net/browse/OSIDB-4845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ